### PR TITLE
Create init_resize script to partition new SD cards

### DIFF
--- a/install/init_resize.sh
+++ b/install/init_resize.sh
@@ -1,0 +1,214 @@
+#!/bin/sh
+# Standard resize_init file modified by BPO as part of the EmonSD project
+# Version 0.1-beta
+# 16 Aug 2019
+# Modifications limit resize of rootfs to around 4GB and create an ext2 partition in remaining space
+
+reboot_pi () {
+  umount /boot
+  mount / -o remount,ro
+  sync
+  if [ "$NOOBS" = "1" ]; then
+    if [ "$NEW_KERNEL" = "1" ]; then
+      reboot -f "$BOOT_PART_NUM"
+    else
+      echo "$BOOT_PART_NUM" > "/sys/module/${BCM_MODULE}/parameters/reboot_part"
+    fi
+  fi
+  echo b > /proc/sysrq-trigger
+  sleep 5
+  exit 0
+}
+
+check_commands () {
+  if ! command -v whiptail > /dev/null; then
+      echo "whiptail not found"
+      sleep 5
+      return 1
+  fi
+  for COMMAND in grep cut sed parted fdisk findmnt partprobe; do
+    if ! command -v $COMMAND > /dev/null; then
+      FAIL_REASON="$COMMAND not found"
+      return 1
+    fi
+  done
+  return 0
+}
+
+check_noobs () {
+  if [ "$BOOT_PART_NUM" = "1" ]; then
+    NOOBS=0
+  else
+    NOOBS=1
+  fi
+}
+
+get_variables () {
+  ROOT_PART_DEV=$(findmnt / -o source -n)
+  ROOT_PART_NAME=$(echo "$ROOT_PART_DEV" | cut -d "/" -f 3)
+  ROOT_DEV_NAME=$(echo /sys/block/*/"${ROOT_PART_NAME}" | cut -d "/" -f 4)
+  ROOT_DEV="/dev/${ROOT_DEV_NAME}"
+  ROOT_PART_NUM=$(cat "/sys/block/${ROOT_DEV_NAME}/${ROOT_PART_NAME}/partition")
+
+  BOOT_PART_DEV=$(findmnt /boot -o source -n)
+  BOOT_PART_NAME=$(echo "$BOOT_PART_DEV" | cut -d "/" -f 3)
+  BOOT_DEV_NAME=$(echo /sys/block/*/"${BOOT_PART_NAME}" | cut -d "/" -f 4)
+  BOOT_PART_NUM=$(cat "/sys/block/${BOOT_DEV_NAME}/${BOOT_PART_NAME}/partition")
+
+  OLD_DISKID=$(fdisk -l "$ROOT_DEV" | sed -n 's/Disk identifier: 0x\([^ ]*\)/\1/p')
+
+  check_noobs
+
+  ROOT_DEV_SIZE=$(cat "/sys/block/${ROOT_DEV_NAME}/size")
+#  TARGET_END=$((ROOT_DEV_SIZE - 1))
+
+#EmonSD Fix end of Rootfs
+  TARGET_END=$((8960000 - 1))
+#EmonSD set start of ext2 partition
+  EXT2_START=$((TARGET_END + 1))
+
+  PARTITION_TABLE=$(parted -m "$ROOT_DEV" unit s print | tr -d 's')
+
+  LAST_PART_NUM=$(echo "$PARTITION_TABLE" | tail -n 1 | cut -d ":" -f 1)
+
+  ROOT_PART_LINE=$(echo "$PARTITION_TABLE" | grep -e "^${ROOT_PART_NUM}:")
+  ROOT_PART_START=$(echo "$ROOT_PART_LINE" | cut -d ":" -f 2)
+  ROOT_PART_END=$(echo "$ROOT_PART_LINE" | cut -d ":" -f 3)
+
+  if [ "$NOOBS" = "1" ]; then
+    EXT_PART_LINE=$(echo "$PARTITION_TABLE" | grep ":::;" | head -n 1)
+    EXT_PART_NUM=$(echo "$EXT_PART_LINE" | cut -d ":" -f 1)
+    EXT_PART_START=$(echo "$EXT_PART_LINE" | cut -d ":" -f 2)
+    EXT_PART_END=$(echo "$EXT_PART_LINE" | cut -d ":" -f 3)
+  fi
+}
+
+fix_partuuid() {
+  DISKID="$(fdisk -l "$ROOT_DEV" | sed -n 's/Disk identifier: 0x\([^ ]*\)/\1/p')"
+
+  sed -i "s/${OLD_DISKID}/${DISKID}/g" /etc/fstab
+  sed -i "s/${OLD_DISKID}/${DISKID}/" /boot/cmdline.txt
+}
+
+check_variables () {
+  if [ "$NOOBS" = "1" ]; then
+    if [ "$EXT_PART_NUM" -gt 4 ] || \
+       [ "$EXT_PART_START" -gt "$ROOT_PART_START" ] || \
+       [ "$EXT_PART_END" -lt "$ROOT_PART_END" ]; then
+      FAIL_REASON="Unsupported extended partition"
+      return 1
+    fi
+  fi
+
+  if [ "$BOOT_DEV_NAME" != "$ROOT_DEV_NAME" ]; then
+      FAIL_REASON="Boot and root partitions are on different devices"
+      return 1
+  fi
+
+  if [ "$ROOT_PART_NUM" -ne "$LAST_PART_NUM" ]; then
+    FAIL_REASON="Root partition should be last partition"
+    return 1
+  fi
+
+  if [ "$ROOT_PART_END" -gt "$TARGET_END" ]; then
+    FAIL_REASON="Root partition runs past the end of device"
+    return 1
+  fi
+
+  if [ ! -b "$ROOT_DEV" ] || [ ! -b "$ROOT_PART_DEV" ] || [ ! -b "$BOOT_PART_DEV" ] ; then
+    FAIL_REASON="Could not determine partitions"
+    return 1
+  fi
+}
+
+check_kernel () {
+  local MAJOR=$(uname -r | cut -f1 -d.)
+  local MINOR=$(uname -r | cut -f2 -d.)
+  if [ "$MAJOR" -eq "4" ] && [ "$MINOR" -lt "9" ]; then
+    return 0
+  fi
+  if [ "$MAJOR" -lt "4" ]; then
+    return 0
+  fi
+  NEW_KERNEL=1
+}
+
+main () {
+  get_variables
+
+  if ! check_variables; then
+    return 1
+  fi
+
+  check_kernel
+
+  if [ "$NOOBS" = "1" ] && [ "$NEW_KERNEL" != "1" ]; then
+    BCM_MODULE=$(grep -e "^Hardware" /proc/cpuinfo | cut -d ":" -f 2 | tr -d " " | tr '[:upper:]' '[:lower:]')
+    if ! modprobe "$BCM_MODULE"; then
+      FAIL_REASON="Couldn't load BCM module $BCM_MODULE"
+      return 1
+    fi
+  fi
+
+  if [ "$ROOT_PART_END" -eq "$TARGET_END" ]; then
+    reboot_pi
+  fi
+
+  if [ "$NOOBS" = "1" ]; then
+    if ! parted -m "$ROOT_DEV" u s resizepart "$EXT_PART_NUM" yes "$TARGET_END"; then
+      FAIL_REASON="Extended partition resize failed"
+      return 1
+    fi
+  fi
+
+  if ! parted -m "$ROOT_DEV" u s resizepart "$ROOT_PART_NUM" "$TARGET_END"; then
+    FAIL_REASON="Root partition resize failed"
+    return 1
+  fi
+
+  #EmonSD EXT2 Partition
+  if ! parted -m "$ROOT_DEV" u s mkpart primary ext2 "$EXT2_START" 100%; then
+    FAIL_REASON="EXT2 partition creation failed"
+    return 1
+  fi
+
+  partprobe "$ROOT_DEV"
+  fix_partuuid
+
+  #EmonSD file to indicate new partitions have been created
+  touch /boot/emonsdinit
+
+  return 0
+}
+
+mount -t proc proc /proc
+mount -t sysfs sys /sys
+mount -t tmpfs tmp /run
+mkdir -p /run/systemd
+
+mount /boot
+mount / -o remount,rw
+
+sed -i 's| init=/usr/lib/raspi-config/init_resize\.sh||' /boot/cmdline.txt
+sed -i 's| sdhci\.debug_quirks2=4||' /boot/cmdline.txt
+
+if ! grep -q splash /boot/cmdline.txt; then
+  sed -i "s/ quiet//g" /boot/cmdline.txt
+fi
+sync
+
+echo 1 > /proc/sys/kernel/sysrq
+
+if ! check_commands; then
+  reboot_pi
+fi
+
+if main; then
+  whiptail --infobox "Resized root filesystem. Rebooting in 5 seconds..." 20 60
+  sleep 5
+else
+  sleep 5
+  whiptail --msgbox "Could not expand filesystem, please try raspi-config or rc_gui.\n${FAIL_REASON}" 20 60
+fi
+
+reboot_pi


### PR DESCRIPTION
The purpose of this PR is to enable the install process to expand the rootfs to a fixed size and create an ext2 partition in the remaining space on SD Cards with a fresh Raspbian Lite Image. This removes the need to format the SD Card on a separate system.

Reasons for preferring ext2 for data is discussed eleswhere.

Concept
1. Prevent the automatic resizing of the rootfs to occur on first boot of a Raspbian Lite image.  It is easier to grow the partition than shrink it.
2. Modify the stock resize file to suit our needs
3. Reinstate the stock automatic resize process
4. Reboot
5. Finalise setup

This revised `init_resize.sh` has only been slightly amended from stock to;
1. Fix the size of the rootfs partition (2) to about 4GB
2. Make a new ext2 partition (3) to fill the remaining space.
3. Add a file in `/boot` to inform the Emoncms install script that the resize has been done.

User Process:
1. Before first boot copy the default `cmdline.txt` to `cmdline2.txt` in the boot folder
2. Edit `cmdline.txt` and remove the `init` statement (I take out the `quiet` as well).
3. Add `ssh` file.
2. Boot Raspberry Pi.

At this point the normal install script process *can* take over.  The script will need to do the following

1. Replace the stock file `/usr/lib/raspi-config/init_resize.sh` with this file.
4. Edit `cmdline.txt` back to original (or rename your copy)
4. Reboot (this will run the `init_resize.sh` process).
5. Complete the following actions post boot (these can be done on the basis of a 'emonsdinit' file being in the `/boot/` folder):
```
sudo resize2fs /dev/mmcblk0p2
sudo mkfs.ext2 -b 1024 /dev/mmcblk0p3
sudo mkdir /var/opt/emoncms
sudo chown www-data /var/opt/emoncms
```

I note that the current process replaces the `/etc/fstab` I think this is a mistake and instead it should be amended with a suitable entry.

A final reboot and the remaining Emoncms install can continue.

This can of course be made optional for non Raspbian based systems.

Stock `cmdline.txt` - used for second boot.
```
dwc_otg.lpm_enable=0 console=serial0,115200 console=tty1 root=PARTUUID=17869b7d-02 rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait quiet init=/usr/lib/raspi-config/init_resize.sh
```
After modification so used for first boot
```
dwc_otg.lpm_enable=0 console=serial0,115200 console=tty1 root=PARTUUID=17869b7d-02 rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait
```
Obviously the PARTUUID will be different.

Note:
1. When Raspbian runs the stock `init_resize` it expands the rootfs. For an unknown reason this does not happen with the modified version so the manual `resize2fs` is required.

This was all new to me so comments etc welcomed!