### PR TITLE
Update emoncms_modules.sh

### DIFF
--- a/install/emoncms_modules.sh
+++ b/install/emoncms_modules.sh
@@ -26,6 +26,12 @@ if [ -d $emoncms_www/Modules/wifi ]; then
     sudo chmod 644 /etc/wpa_supplicant/wpa_supplicant.conf
 fi
 
+if [ ! -d $emoncms_dir ]
+then
+    sudo mkdir $emoncms_dir
+    sudo chown $USER $emoncms_dir
+fi
+
 # Install emoncms modules that do not reside in /var/www/emoncms/Modules
 if [ ! -d $emoncms_dir/modules ]; then
     mkdir $emoncms_dir/modules


### PR DESCRIPTION
If somebody does not use init.sh and launches main.sh without creating emoncms_dir, it can result a disorder, all symlinked modules being dropped in emoncms_www/Modules
These lines can prevent such a situation