### PR TITLE
Option to change all installed repositories to `master` branch

### DIFF
--- a/install/init.sh
+++ b/install/init.sh
@@ -17,10 +17,14 @@ cd $openenergymonitor_dir
 
 git clone https://github.com/openenergymonitor/EmonScripts.git
 cd $openenergymonitor_dir/EmonScripts
-git checkout stable
+if [ "$1" != "" ]; then
+    git checkout $1
+else
+    git checkout stable
+fi
 
 cd $openenergymonitor_dir/EmonScripts/install
-./main.sh
+./main.sh $1
 cd
 
 rm init.sh

--- a/install/main.sh
+++ b/install/main.sh
@@ -17,8 +17,8 @@
 if [ ! -f config.ini ]; then
     cp emonsd.config.ini config.ini
     if [ "$1" != "" ]; then
-        echo "Positional parameter 1 contains something replace branch"
-        sed 's/stable/master/g' config.ini
+        echo "Set $1 branch"
+        sed -i "s/stable/$1/g" config.ini
     fi
 fi
 

--- a/install/main.sh
+++ b/install/main.sh
@@ -16,7 +16,12 @@
 #!/bin/bash
 if [ ! -f config.ini ]; then
     cp emonsd.config.ini config.ini
+    if [ "$1" != "" ]; then
+        echo "Positional parameter 1 contains something replace branch"
+        sed 's/stable/master/g' config.ini
+    fi
 fi
+
 source load_config.sh
     
 echo "-------------------------------------------------------------"

--- a/install/readme.md
+++ b/install/readme.md
@@ -17,7 +17,7 @@ As at 7 Oct 19 - Tested on:
 
 ### RaspberryPi
 
-To install onto a RaspberryPi, a number of tasks are required. Please follow [this instruction first](https://github.com/openenergymonitor/EmonScripts/blob/master/install/rpi-install.md).
+To install onto a RaspberryPi, a number of tasks are required. Please follow [this instruction first](rpi-install.md).
 
 ### Ubuntu
 

--- a/install/readme.md
+++ b/install/readme.md
@@ -29,20 +29,28 @@ sudo echo $USER' ALL=(ALL) NOPASSWD: ALL' | sudo tee /etc/sudoers.d/$USER && sud
 
 ### Digital Ocean Droplet
 
-For installation on a Digital Ocean Droplet, follow [this instruction](https://github.com/openenergymonitor/EmonScripts/blob/stable/install/digital-ocean-install.md).
+For installation on a Digital Ocean Droplet, follow [this instruction](digital-ocean-install.md).
 
 ## Install the EmonCMS Installation Scripts
 
-Pull the script from GitHub (note if you wish to pull the script from `master` change the path).
+Pull the init script from GitHub (note if you wish to pull the script from `master` change the path).
 
 ```shell
 wget https://raw.githubusercontent.com/openenergymonitor/EmonScripts/stable/install/init.sh
 chmod +x init.sh && ./init.sh
 ```
 
+To use the `master` branch for **all** repositories use the command;
+
+```shell
+chmod +x init.sh && ./init.sh master
+```
+
 The `init` script automatically calls the `main` script. At this point you will be offered the option to configure the installation process.
 
 If you are on a RaspberryPi or EmonPi you can usually just proceed.
+
+If you wish to change any repository to master or change any other configuration, then edit the `config.ini` file.
 
 The Install process does takes sometime.
 
@@ -75,11 +83,11 @@ To restart the installation:
 ./main.sh
 ```
 
-See explanation and settings in installation configuration file here: [config.ini](https://github.com/openenergymonitor/EmonScripts/blob/stable/install/emonsd.config.ini)
+See explanation and settings in installation configuration file here: [config.ini](emonsd.config.ini)
 
 ## Run Scripts Individually
 
-It is possible to run the [scripts individually](https://github.com/openenergymonitor/EmonScripts/blob/stable/install/install-scripts.md) for a single part of the stack. These are not guaranteed to be a complete solution (some folders may not be created for instance).
+It is possible to run the [scripts individually](install-scripts.md) for a single part of the stack. These are not guaranteed to be a complete solution (some folders may not be created for instance).
 
 ## Standard Setup Filepaths
 


### PR DESCRIPTION
By providing a parameter to `config.ini` of **master**, it is possible to change all installed repositories to master. No parameter just runs as standard.

Not very elegant but quite effective now there are stable/master branches.

By changing the names at the point of creating the `config.ini`, it is still changeable before install.

Seems to work but because of hardcoded repositories, a little difficult to test.
