### PR TITLE
pip3 and python3 not installed

### DIFF
--- a/update/emonhub.sh
+++ b/update/emonhub.sh
@@ -34,6 +34,8 @@ if [ -d $openenergymonitor_dir/emonhub ]; then
         # Temporary addition of paho-mqtt & requests here
         # remove once issue has cleared:
         # https://community.openenergymonitor.org/t/emonpi-new-sd-image-emonhub-failing/14578
+        sudo apt update
+        sudo apt-get install -y python3-serial python3-configobj python3-pip
         sudo pip3 install paho-mqtt requests
     fi 
     


### PR DESCRIPTION
add in the install of python3 pip3 - this is a bit of a cludge. There should be an update script in the emonhub folder or else run the installer again.

#99 