### PR TITLE
Reduce MAX SIZE in logrotate

### DIFF
--- a/defaults/etc/logrotate.d/00_defaults
+++ b/defaults/etc/logrotate.d/00_defaults
@@ -1,4 +1,4 @@
-maxsize 500k
+maxsize 250k
 
 /var/log/logrotate/*.log {
         rotate 7


### PR DESCRIPTION
I have hit an issue where there is not enough space to write the existing log file before it gets truncated.

This will result in `/var/log/` filling up again (just more slowly than before).

This may fix it.