### PR TITLE
Install script fixes and documentation tweaks

### DIFF
--- a/install/main.sh
+++ b/install/main.sh
@@ -61,7 +61,7 @@ fi
 if [ ! -d $openenergymonitor_dir/data ]; then mkdir $openenergymonitor_dir/data; fi
 
 echo "-------------------------------------------------------------"
-sudo apt-get install -y git build-essential python-pip python-dev gettext
+sudo apt-get install -y git build-essential python3-pip python3-dev gettext
 echo "-------------------------------------------------------------"
 
 if [ "$install_apache" = true ]; then $openenergymonitor_dir/EmonScripts/install/apache.sh; fi

--- a/install/main.sh
+++ b/install/main.sh
@@ -61,7 +61,10 @@ fi
 if [ ! -d $openenergymonitor_dir/data ]; then mkdir $openenergymonitor_dir/data; fi
 
 echo "-------------------------------------------------------------"
-sudo apt-get install -y git build-essential python-pip python3-pip python-dev python3-dev gettext
+sudo apt-get install -y git build-essential python3-pip python-dev python3-dev gettext
+# From Ubuntu 20.04 pip for python 2 is no longer in their repositories
+# This install is split out as if kept within a single apt-get install none of the packages are installed. This provides a crude fudge to at least get the rest installed, whilst dependent modules are switch to pyhton3
+sudo apt-get install -y python-pip
 echo "-------------------------------------------------------------"
 
 if [ "$install_apache" = true ]; then $openenergymonitor_dir/EmonScripts/install/apache.sh; fi

--- a/install/main.sh
+++ b/install/main.sh
@@ -61,7 +61,7 @@ fi
 if [ ! -d $openenergymonitor_dir/data ]; then mkdir $openenergymonitor_dir/data; fi
 
 echo "-------------------------------------------------------------"
-sudo apt-get install -y git build-essential python3-pip python3-dev gettext
+sudo apt-get install -y git build-essential python-pip python3-pip python-dev python3-dev gettext
 echo "-------------------------------------------------------------"
 
 if [ "$install_apache" = true ]; then $openenergymonitor_dir/EmonScripts/install/apache.sh; fi

--- a/install/readme.md
+++ b/install/readme.md
@@ -105,12 +105,10 @@ If you are migrating from an old system, export your data from the old system an
 
 ## Standard Setup Filepaths
 
-Install location for code from OpenEnergyMonitor GitHub repository such as EmonScripts `/opt/openenergymonitor`
-
-Install location for modules symlinked to www `/opt/emoncms`
-
-Main code location `/var/www/emoncms`
-
-Log file location `/var/log/emoncms`
-
-Data directory `/var/opt/emoncms`
+| Role       | Location     |
+| :------------- | :----------- |
+| Install location for code from OpenEnergyMonitor GitHub repository such as EmonScripts  | `/opt/openenergymonitor` |
+| Install location for modules symlinked to www  | `/opt/emoncms` |
+| Main code location  | `/var/www/emoncms` |
+| Log file location   | `/var/log/emoncms` |
+| Data directory      | `/var/opt/emoncms` |

--- a/install/readme.md
+++ b/install/readme.md
@@ -68,21 +68,9 @@ If you are on a RaspberryPi or EmonPi you can usually just proceed.
 
 Be patient, the install process takes some time.
 
-## Post Install - Settings
-
-If you have used EmonCMS before, you may need to edit the settings to suit your local setup. This is now an `ini` file called `settings.ini` in `/var/www/emoncms/`.
-
-## Post Install - First Use
-
-To access EmonCMS go to the IP of your machine, in your browser.  This [Guide](https://guide.openenergymonitor.org/setup/connect/) will help you set your system up.
-
-At the initial user screen, you need to select **Register** and create a user - this will be the admin user.
-
-If you are migrating from an old system, export your data from the old system and import the data to the new system (after registering a user). This will require you to login as the original user.
-
 ## Configure install
 
-The default configuration is specifically for the RaspberryPi platform and Raspbian Buster image. To run the installation on a different distribution, you may need to change the configuration to reflect the target environment.
+The default configuration is specifically for the RaspberryPi platform and Raspbian Buster image. To run the installation on a different distribution, you may need to change the configuration to reflect the target environment, e.g. set `emonSD_pi_env=0`
 
 To edit the configuration (standard file paths):
 
@@ -102,6 +90,18 @@ See explanation and settings in the installation configuration file here: [confi
 ## Run Scripts Individually
 
 It is possible to run the [scripts individually](https://github.com/openenergymonitor/EmonScripts/blob/stable/install/install-scripts.md) for a single part of the stack. These are not guaranteed to be a complete solution (some folders may not be created for instance).
+
+## Post Install - Settings
+
+If you have used EmonCMS before, you may need to edit the settings to suit your local setup. This is now an `ini` file called `settings.ini` in `/var/www/emoncms/`.
+
+## Post Install - First Use
+
+To access EmonCMS go to the IP of your machine, in your browser.  This [Guide](https://guide.openenergymonitor.org/setup/connect/) will help you set your system up.
+
+At the initial user screen, you need to select **Register** and create a user - this will be the admin user.
+
+If you are migrating from an old system, export your data from the old system and import the data to the new system (after registering a user). This will require you to login as the original user.
 
 ## Standard Setup Filepaths
 

--- a/install/redis.sh
+++ b/install/redis.sh
@@ -17,7 +17,7 @@ if [ "$install_php" = true ]; then
     sudo phpenmod redis
 fi
 
-sudo pip install redis
+sudo pip3 install redis
 
 # Disable redis persistance
 sudo sed -i "s/^save 900 1/#save 900 1/" /etc/redis/redis.conf

--- a/install/redis.sh
+++ b/install/redis.sh
@@ -17,7 +17,7 @@ if [ "$install_php" = true ]; then
     sudo phpenmod redis
 fi
 
-sudo pip3 install redis
+pip3 install redis
 
 # Disable redis persistance
 sudo sed -i "s/^save 900 1/#save 900 1/" /etc/redis/redis.conf


### PR DESCRIPTION
A few tweaks to the install documentation to prevent the situation I hit where I didn't check the config file and hence didn't what I needed for an Ubuntu VM. And placing the locations into a table.
I've also changed the install scripts to use Python3 in alignment with the update script changes previously made