### PR TITLE
Log the free space on each filesystem

### DIFF
--- a/update/service-runner-update.sh
+++ b/update/service-runner-update.sh
@@ -28,6 +28,8 @@ if [ "$varlog_available" -lt "1024" ]; then
 fi
 
 echo "Starting update via service-runner-update.sh (v3.0) >"
+# Log the free space on each filesystem.
+df -h
 
 # -----------------------------------------------------------------
 


### PR DESCRIPTION
Often helpful for troubleshooting, and a question very commonly asked, so log it up front to help those providing assistance to users.