### PR TITLE
Fix init_resize.sh on Bullseye NOOBS images

### DIFF
--- a/install/init_resize.sh
+++ b/install/init_resize.sh
@@ -182,7 +182,7 @@ main () {
   fi
 
   if [ "$NOOBS" = "1" ]; then
-    if ! parted -m "$ROOT_DEV" u s resizepart "$EXT_PART_NUM" yes "$TARGET_END"; then
+    if ! printf "resizepart %s\nyes\n%ss\n" "$EXT_PART_NUM" "$TARGET_END" | parted "$ROOT_DEV" ---pretend-input-tty; then
       FAIL_REASON="Extended partition resize failed"
       return 1
     fi


### PR DESCRIPTION
following changes from the original init_resize.sh 

cf https://github.com/RPi-Distro/raspi-config/commit/d6b4e8d72017f36a1238f292d75cc3edf0c75b60

Even if it doesn't have much impact, it's better not to diverge too much from the original file 