### PR TITLE
Available Logspace line is failing

### DIFF
--- a/update/service-runner-update.sh
+++ b/update/service-runner-update.sh
@@ -22,7 +22,7 @@ fi
 cat /dev/null > /var/log/emoncms/emonupdate.log
 
 # Find largest log file and remove
-varlog_available=$(df | awk '$NF == "/var/log" { print $4 }')
+varlog_available=$(df --output=avail /var/log | tail -n 1)
 if [ "$varlog_available" -lt "1024" ]; then
     largest_log_file=$(sudo find /var/log -type f -printf "%s\t%p\n" | sort -n | tail -1 | cut -f 2)
     sudo truncate -s 0 $largest_log_file


### PR DESCRIPTION
Issue #151 

I do not know why the current line is failing, but from the command line this works.
```
$ df --output=avail /var/log | tail -n 1
45656
```