### PR TITLE
Modify logrotate schema

### DIFF
--- a/defaults/etc/logrotate.d/00_defaults
+++ b/defaults/etc/logrotate.d/00_defaults
@@ -1,13 +1,1 @@
 maxsize 250k
-
-/var/log/logrotate/*.log {
-        rotate 7
-        daily
-        compress
-        copytruncate
-        size 100k
-        nocreate
-        missingok
-        notifempty
-        delaycompress
-}

--- a/defaults/etc/logrotate.d/emoncms
+++ b/defaults/etc/logrotate.d/emoncms
@@ -3,4 +3,5 @@
     compress
     olddir /var/log.old/emoncms
     createolddir 775 root root
+    renamecopy
 }

--- a/defaults/etc/logrotate.d/emoncms-non-emonsd
+++ b/defaults/etc/logrotate.d/emoncms-non-emonsd
@@ -3,7 +3,7 @@
         daily
         compress
         copytruncate
-        size 100k
+        size 3M
         nocreate
         missingok
         notifempty

--- a/defaults/etc/logrotate.d/emonhub
+++ b/defaults/etc/logrotate.d/emonhub
@@ -1,11 +1,7 @@
 /var/log/emonhub/emonhub.log {
     maxsize 3M
-
-    norenamecopy
-    copytruncate
-    su root root
     compress
-    
     olddir /var/log.old/emonhub
     createolddir 775 root root
+    renamecopy
 }

--- a/defaults/etc/logrotate.d/logrotate
+++ b/defaults/etc/logrotate.d/logrotate
@@ -1,0 +1,9 @@
+/var/log/logrotate/*.log {
+        rotate 7
+        daily
+        compress
+        nocreate
+        missingok
+        notifempty
+        delaycompress
+}

--- a/install/emonsd.sh
+++ b/install/emonsd.sh
@@ -25,10 +25,12 @@ fi
 sudo ln -sf $openenergymonitor_dir/EmonScripts/defaults/etc/logrotate.d/00_defaults /etc/logrotate.d/00_defaults
 sudo ln -sf $openenergymonitor_dir/EmonScripts/defaults/etc/logrotate.d/emonhub /etc/logrotate.d/emonhub
 sudo ln -sf $openenergymonitor_dir/EmonScripts/defaults/etc/logrotate.d/emoncms /etc/logrotate.d/emoncms
+sudo ln -sf $openenergymonitor_dir/EmonScripts/defaults/etc/logrotate.d/logrotate /etc/logrotate.d/logrotate
 
 sudo chown root /etc/logrotate.d/00_defaults
 sudo chown root /etc/logrotate.d/emonhub
 sudo chown root /etc/logrotate.d/emoncms
+sudo chown root /etc/logrotate.d/logrotate
 
 # log2ram cron hourly entry
 sudo ln -sf $openenergymonitor_dir/EmonScripts/defaults/etc/cron.hourly/log2ram /etc/cron.hourly/log2ram


### PR DESCRIPTION
Modify the logrotate commands to ensure all logs get rotated to the SD card by log2ram.

Changes as well because of changes to Logrotate itself.

#155 refers