### PR TITLE
Create www and log folders for Apache

### DIFF
--- a/install/apache.sh
+++ b/install/apache.sh
@@ -6,6 +6,25 @@ echo "Apache configuration"
 echo "-------------------------------------------------------------"
 sudo apt-get install -y apache2 gettext
 
+sudo chown $user /var/www
+
+# create emoncms www folder
+if [ ! -d $emoncms_www ]; then
+    echo "- create emoncms www folder for Apache"
+    mkdir $emoncms_www
+else
+    echo "- emoncms www folder already installed"
+fi
+
+# Create emoncms logfolder
+if [ ! -d $emoncms_log_location ]; then
+    echo "- creating emoncms log folder"
+    sudo mkdir $emoncms_log_location
+    sudo chown $user $emoncms_log_location
+else
+    echo "- log folder already exists"
+fi
+
 sudo sed -i "s/^CustomLog/#CustomLog/" /etc/apache2/conf-available/other-vhosts-access-log.conf
 
 # Enable apache mod rewrite

--- a/install/emoncms_core.sh
+++ b/install/emoncms_core.sh
@@ -9,22 +9,29 @@ echo "-------------------------------------------------------------"
 sudo chown $user /var/www
 
 # Install emoncms core repository with git
-if [ ! -d $emoncms_www ]; then
+if [ -f "$emoncms_www/version.json" ]; then
+    echo "- emoncms already installed"
+else
     cd /var/www && git clone -b $emoncms_core_branch ${git_repo[emoncms_core]}
     cd
-else
-    echo "- emoncms already installed"
 fi
 
 # Create emoncms logfolder
-if [ ! -f $emoncms_log_location ]; then
+if [ ! -d $emoncms_log_location ]; then
     echo "- creating emoncms log folder"
     sudo mkdir $emoncms_log_location
     sudo chown $user $emoncms_log_location
+else
+    echo "- log folder already exists"
+fi
+
+# Create emoncms logfile
+if [ ! -f "$emoncms_log_location/emoncms.log" ]; then
+    echo "- creating emoncms log file"
     sudo touch "$emoncms_log_location/emoncms.log"
     sudo chmod 666 "$emoncms_log_location/emoncms.log"
 else
-    echo "- log folder already exists"
+    echo "- log file already exists"
 fi
 
 # Copy and install emonpi.settings.ini


### PR DESCRIPTION
#154 #41 

Add the creation of the `www` and the `log` folders for emoncms before Apache is installed.

Because the VHosts file references them, they need to be created before emoncms is installed.

Modify the `emoncms-core` script to allow for the folders to have been already created.

**Note** the apache config files have hardcoded locations for the log and www. These should follow the `settings` file. #61 
