### PR TITLE
Add git safe directory command to install script

### DIFF
--- a/install/main.sh
+++ b/install/main.sh
@@ -69,6 +69,10 @@ if [ "$apt_get_upgrade_and_clean" = true ]; then
     fi
 fi
 
+# Required to allow the webserver to use git commands. ref 
+# https://community.openenergymonitor.org/t/ubuntu-22-04-lxc-install-issues-git/22189/1
+sudo git config --system --add safe.directory '*'
+
 # Required for emonpiLCD, wifi, rfm69pi firmware (review)
 if [ ! -d $openenergymonitor_dir/data ]; then mkdir $openenergymonitor_dir/data; fi
 

--- a/update/main.sh
+++ b/update/main.sh
@@ -64,6 +64,11 @@ fi
 if [ "$type" == "all" ] || [ "$type" == "emonhub" ]; then
     echo "Running apt-get update"
     sudo apt-get update
+    # Required to allow the webserver to use git commands. ref 
+    # https://community.openenergymonitor.org/t/ubuntu-22-04-lxc-install-issues-git/22189/1
+    # Not enabled on update yet
+
+    # sudo git config --system --add safe.directory '*'
 fi
 
 # -----------------------------------------------------------------


### PR DESCRIPTION
Required to allow the webserver to use git commands. ref  https://community.openenergymonitor.org/t/ubuntu-22-04-lxc-install-issues-git/22189/1

Symptom is the components page no longer showing the branch in use.

This will be obvious on an up to date base system. Packages updated since Nov22 image created;

```
git-man/stable 1:2.30.2-1+deb11u1 all [upgradable from: 1:2.30.2-1]
git/stable 1:2.30.2-1+deb11u1 armhf [upgradable from: 1:2.30.2-1]
```

Command required

```
sudo git config --system --add safe.directory '*'
```