### PR TITLE
Enhancement to log init.sh and main.sh install scripts from issue https://github.com/openenergymonitor/EmonScripts/issues/64

### DIFF
--- a/docs/install-scripts.md
+++ b/docs/install-scripts.md
@@ -4,9 +4,9 @@ All these links, link to the `stable` branch.
 
 The installation process is broken out into separate scripts that can be run individually.
 
-**[init.sh:](https://github.com/openenergymonitor/EmonScripts/blob/stable/install/init.sh)** Launches the full installation script, first downloading the EmonScripts repository that contains the rest of the installation scripts. All output sent to screen also stored in `/tmp/init.sh.log`.
+**[init.sh:](https://github.com/openenergymonitor/EmonScripts/blob/stable/install/init.sh)** Launches the full installation script, first downloading the EmonScripts repository that contains the rest of the installation scripts. All output sent to screen also stored in the user's home directory `~/init.sh.log`.
 
-**[main.sh:](https://github.com/openenergymonitor/EmonScripts/blob/stable/install/main.sh)** Loads the configuration file and runs the individual installation scripts as applicable. All output sent to screen also stored in `/tmp/main.sh.log`.
+**[main.sh:](https://github.com/openenergymonitor/EmonScripts/blob/stable/install/main.sh)** Loads the configuration file and runs the individual installation scripts as applicable. All output sent to screen also stored in the user's home directory `~/main.sh.log`.
 
 ---
 

--- a/docs/install-scripts.md
+++ b/docs/install-scripts.md
@@ -4,9 +4,9 @@ All these links, link to the `stable` branch.
 
 The installation process is broken out into separate scripts that can be run individually.
 
-**[init.sh:](https://github.com/openenergymonitor/EmonScripts/blob/stable/install/init.sh)** Launches the full installation script, first downloading the EmonScripts repository that contains the rest of the installation scripts.
+**[init.sh:](https://github.com/openenergymonitor/EmonScripts/blob/stable/install/init.sh)** Launches the full installation script, first downloading the EmonScripts repository that contains the rest of the installation scripts. All output sent to screen also stored in `/tmp/init.sh.log`.
 
-**[main.sh:](https://github.com/openenergymonitor/EmonScripts/blob/stable/install/main.sh)** Loads the configuration file and runs the individual installation scripts as applicable.
+**[main.sh:](https://github.com/openenergymonitor/EmonScripts/blob/stable/install/main.sh)** Loads the configuration file and runs the individual installation scripts as applicable. All output sent to screen also stored in `/tmp/main.sh.log`.
 
 ---
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -41,6 +41,8 @@ chmod +x init.sh && ./init.sh
 
 The `init` script automatically calls the `main` script. At this point you will be offered the option to configure the installation process.
 
+Output from `init.sh` is displayed on screen and also stored in `/tmp/init.sh.log`. Output from `main.sh` is also displayed on screen and stored in `/tmp/main.sh.log`.
+
 If you are on a RaspberryPi or EmonPi you can usually just proceed.
 
 Be patient, the install process takes some time.

--- a/docs/install.md
+++ b/docs/install.md
@@ -41,7 +41,7 @@ chmod +x init.sh && ./init.sh
 
 The `init` script automatically calls the `main` script. At this point you will be offered the option to configure the installation process.
 
-Output from `init.sh` is displayed on screen and also stored in `/tmp/init.sh.log`. Output from `main.sh` is also displayed on screen and stored in `/tmp/main.sh.log`.
+Output from `init.sh` is displayed on screen and also stored in the user's home directory `~/init.sh.log`. Output from `main.sh` is also displayed on screen and stored in the user's home directory `~/main.sh.log`.
 
 If you are on a RaspberryPi or EmonPi you can usually just proceed.
 

--- a/install/init.sh
+++ b/install/init.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# Copy stdout and stderr to a log file in addition to the console
+# tee -a used in case script is run multiple times
+
+LOG_FILE=/tmp/$(basename "$0").log
+exec > >(tee -a "${LOG_FILE}") 2>&1
+
+echo "Script output also stored in ${LOG_FILE}"
+echo -e "Started: $(date)\n"
+
 user=$USER
 openenergymonitor_dir=/opt/openenergymonitor
 emoncms_dir=/opt/emoncms
@@ -24,3 +33,5 @@ cd $openenergymonitor_dir/EmonScripts/install
 cd
 
 rm init.sh
+
+echo -e "\nScript output also stored in ${LOG_FILE}"

--- a/install/init.sh
+++ b/install/init.sh
@@ -3,7 +3,7 @@
 # Copy stdout and stderr to a log file in addition to the console
 # tee -a used in case script is run multiple times
 
-LOG_FILE=/tmp/$(basename "$0").log
+LOG_FILE=~/$(basename "$0").log
 exec > >(tee -a "${LOG_FILE}") 2>&1
 
 echo "Script output also stored in ${LOG_FILE}"

--- a/install/main.sh
+++ b/install/main.sh
@@ -17,7 +17,7 @@
 # Copy stdout and stderr to a log file in addition to the console
 # tee -a used in case script is run multiple times
 
-LOG_FILE=/tmp/$(basename "$0").log
+LOG_FILE=~/$(basename "$0").log
 exec > >(tee -a "${LOG_FILE}") 2>&1
 
 echo "Script output also stored in ${LOG_FILE}"

--- a/install/main.sh
+++ b/install/main.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # --------------------------------------------------------------------------------
 # RaspberryPi Strech Build Script
 # Emoncms, Emoncms Modules, EmonHub & dependencies
@@ -13,12 +14,20 @@
 # - emonhub installer
 # Format as documentation
 
+# Copy stdout and stderr to a log file in addition to the console
+# tee -a used in case script is run multiple times
+
+LOG_FILE=/tmp/$(basename "$0").log
+exec > >(tee -a "${LOG_FILE}") 2>&1
+
+echo "Script output also stored in ${LOG_FILE}"
+echo -e "Started: $(date)\n"
+
 # fix interactive popup that keeps asking for service restart
 if [ -f /etc/needrestart/needrestart.conf ]; then
   sudo sed -i 's/#$nrconf{restart} = '"'"'i'"'"';/$nrconf{restart} = '"'"'a'"'"';/g' /etc/needrestart/needrestart.conf
 fi
 
-#!/bin/bash
 if [ ! -f config.ini ]; then
     cp emonsd.config.ini config.ini
 fi
@@ -100,13 +109,8 @@ if [ "$emonSD_pi_env" = "1" ]; then
     # update checks for image type and only runs with a valid image name file in the boot partition
     # Update this value to the latest safe image version - this could be automated to pull from safe list
     sudo touch /boot/emonSD-10Nov22
-    exit 0
-    # Reboot to complete
-    sudo reboot
 else
     $openenergymonitor_dir/EmonScripts/install/non_emonsd.sh;
-    # sudo touch /boot/emonSD-30Oct18
-    exit 0
-    # Reboot to complete
-    sudo reboot
 fi
+
+echo -e "\nScript output also stored in ${LOG_FILE}"


### PR DESCRIPTION
In response to issue (enhancement) https://github.com/openenergymonitor/EmonScripts/issues/64

The install.sh and main.sh have been updated to copy stdout and stderr to both the terminal and also a log file.
The script echos the log file name at the beginning and end of the script
'tee -a' used in case the scripts are run multiple times
In addition main.sh is changed to move the shell directive to the top of the script and to remove superfluous code after the "exit 0" in the final if statement. Also removed the exit to enable the script output to be shown using one command after the if

Example of `init.sh` output at the start:
![image](https://user-images.githubusercontent.com/33792140/227703297-30faa865-389d-4a97-968e-f18f16751437.png)


End of `init.sh`, including where it triggers `main.sh`, which shows where it's output is stored:
![image](https://user-images.githubusercontent.com/33792140/227703337-aa1f49be-798f-4565-b67d-b9aa9149d258.png)

`main.sh` doesn't show share confirmation of log file contents when the user chooses to edit the config files, but could be easily added

And then when running `main.sh` for the real install:
![image](https://user-images.githubusercontent.com/33792140/227703436-1b2b5619-ae23-453b-8c6b-c856685c017a.png)

And the end of `main.sh`:
![image](https://user-images.githubusercontent.com/33792140/227703531-b74b21f3-7603-4cd2-9b33-440cdb4306ad.png)
